### PR TITLE
Put jQuery code inside the anonymous "remap jQuery to $" function

### DIFF
--- a/_/js/functions.js
+++ b/_/js/functions.js
@@ -1,5 +1,5 @@
 // remap jQuery to $
-(function($){})(window.jQuery);
+(function($){
 
 
 /* trigger when page is ready */
@@ -21,3 +21,6 @@ $(window).resize(function() {
 });
 
 */
+
+
+})(window.jQuery);


### PR DESCRIPTION
At _/js/functions.js, it uses an anonymous function to have a local `$` variable with jQuery. That `$` variable only exists inside the anonymous function, so the current way its written doesn't make much sense - the rest of the code should be inside that anonymous function too.
