### PR TITLE
Make [hidden] more !important

### DIFF
--- a/_/css/style.css
+++ b/_/css/style.css
@@ -25,7 +25,7 @@ html, body, body div, span, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquot
 article, aside, figure, footer, header, hgroup, nav, section {display: block;}
 
 /* compensate for WhatWG's relatively low [hidden] specificity, as otherwise the line above will override this display */
-[hidden] { display: none !important; }
+[hidden] { display: none; }
 
 /* Responsive images and other embedded objects
    Note: keeping IMG here will cause problems if you're using foreground images as sprites.


### PR DESCRIPTION
I was wondering if you'd consider adding the rule

```
[hidden] { display: none !important; }
```

To your reset as it seems like the people in the WhatWG don't want to
make their rule any more specific than `[hidden] { display: none; }`, so
using your awesome reset will result in people having anomalies like:

```
<section hidden>I'm still visible!</section>
```

as

```
/*...*/ section /*...*/ { display: block; }
```

will override this. (http://jsfiddle.net/danbeam/MrEjL/2/)
