### PR TITLE
Added css to set a default placeholder color in mozilla.

### DIFF
--- a/_/css/style.css
+++ b/_/css/style.css
@@ -145,6 +145,9 @@ a:link {-webkit-tap-highlight-color: #fcd700;}
 ins {background-color: #fcd700; color: #000; text-decoration: none;}
 mark {background-color: #fcd700; color: #000; font-style: italic; font-weight: bold;}
 
+/* Mozilla dosen't style place holders by default */
+input:-moz-placeholder { color:#a9a9a9; }
+textarea:-moz-placeholder { color:#a9a9a9; }
 
 
 


### PR DESCRIPTION
Firefox uses #000 for its default place holder. I updated to make it the same as webkit.
