### PR TITLE
Remove cracy IE6 CSS notation in order to be compatible with LESS

### DIFF
--- a/_/css/reset.css
+++ b/_/css/reset.css
@@ -109,9 +109,6 @@ button {width: auto; overflow: visible;}
 /* scale images in IE7 more attractively */
 .ie7 img {-ms-interpolation-mode: bicubic;}
 
-/* prevent BG image flicker upon hover */
-.ie6 html {filter: expression(document.execCommand("BackgroundImageCache", false, true));}
-
 /* let's clear some floats */
 .clearfix:before, .clearfix:after { content: "\0020"; display: block; height: 0; overflow: hidden; }  
 .clearfix:after { clear: both; }  


### PR DESCRIPTION
If you try to include the current reset.css into LESS (in order to combine a bunch of CSS files), you get the error:

```
ParseError: Syntax Error on line 113 in /home/simon/HTML5-Reset/_/css/reset.css:113:11

112 /* prevent BG image flicker upon hover */
113 .ie6 html {filter: expression(document.execCommand("BackgroundImageCache", false, true));}
114
```

This is because LESS does not understand the cracy IE6 CSS notation.

Can we drop this filter in favor of LESS and probably other CSS pre-compilers?
