### PR TITLE
Cross-browser border-box fix

### DIFF
--- a/assets/css/reset.css
+++ b/assets/css/reset.css
@@ -28,6 +28,8 @@ article, aside, figure, footer, header, nav, section, details, summary {display:
    http://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/ */
 html {
 	box-sizing: border-box;
+	-webkit-box-sizing: border-box;
+    	-moz-box-sizing: border-box;
 }
 
 *, 


### PR DESCRIPTION
Border-box not working in some old browsers such as Firefox 27. Added cross-browser support.
