### PR TITLE
Chrome Frame is no retired

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
 
 	<meta charset="utf-8">
 	
-	<!-- Always force latest IE rendering engine (even in intranet) & Chrome Frame -->
-	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+	<!-- Always force latest IE rendering engine (even in intranet) -->
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	
 	<!-- Important stuff for SEO, don't neglect. (And don't dupicate values across your site!) -->
 	<title></title>


### PR DESCRIPTION
Google Chrome Frame is no longer supported and retired as of February 25, 2014.
