### PR TITLE
Added theme-color meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,9 @@
 	<!-- Don't forget to set your site up: http://google.com/webmasters -->
 	<meta name="google-site-verification" content="" />
 	
+	<!-- Use the theme-color meta tag to set the toolbar color. (Chrome for Android on Lollipop), enter a valid color code like #ff0000 -->
+	<meta name="theme-color" content="">
+	
 	<!-- Who owns the content of this site? -->
 	<meta name="Copyright" content="" />
 	


### PR DESCRIPTION
Starting in version 39 of Chrome for Android on Lollipop, you’ll now be able to use the theme-color meta tag to set the toolbar color. More info: http://updates.html5rocks.com/2014/11/Support-for-theme-color-in-Chrome-39-for-Android
