### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "HTML5-Reset",
-  "version": "2.1.2",
   "homepage": "https://github.com/murtaugh/HTML5-Reset",
   "authors": [
     "Tim Murtaugh <tim@o2b.net>"


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property