### PR TITLE
Add package.json with style entry.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "HTML5-Reset",
+  "version": "2.1.3",
+  "homepage": "https://github.com/wbinnssmith/HTML5-Reset",
+  "bugs": {
+    "url": "https://github.com/wbinnssmith/HTML5-Reset/issues"
+  },
+  "author": "Tim Murtaugh <tim@o2b.net>",
+  "description": "A simple set of best practices to get HTML5 projects off on the right foot.",
+  "style": "assets/css/reset.css",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wbinnssmith/HTML5-Reset.git"
+  },
+  "keywords": [
+    "html5",
+    "reset",
+    "css",
+    "templates"
+  ],
+  "license": "MIT"
+}


### PR DESCRIPTION
This allows npm-capable css bundlers like [sheetify](https://github.com/sheetify/sheetify), [postcss-import](https://github.com/postcss/postcss-import), [npm-css](https://github.com/defunctzombie/npm-css), and [rework-npm](https://github.com/reworkcss/rework-npm) to load the reset stylesheet with `@import 'HTML5-Reset'`.

Having a `package.json` also allows this to be installed with npm. Would appreciate if you could publish it to npm too!