### PR TITLE
Use tabs for indentation, spaces for alignment in header

### DIFF
--- a/assets/css/reset.css
+++ b/assets/css/reset.css
@@ -3,9 +3,9 @@
 	----------------------------------------------------------
 	We have learned much from/been inspired by/taken code where offered from:
 
-	Eric Meyer					:: http://meyerweb.com
-	HTML5 Doctor				:: http://html5doctor.com
-	and the HTML5 Boilerplate	:: http://html5boilerplate.com
+	Eric Meyer                      :: http://meyerweb.com
+	HTML5 Doctor                    :: http://html5doctor.com
+	and the HTML5 Boilerplate       :: http://html5boilerplate.com
 
 -------------------------------------------------------------------------------*/
 


### PR DESCRIPTION
Uses tabs for indentation and spaces for alignment in header, since on Github they were all staggered around due to tab widths being 8 spaces.